### PR TITLE
feat: Stop retrieval by adminAreaCode

### DIFF
--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -69,7 +69,7 @@ export type StopsQueryInput = {
     atcoCodes?: string[];
     naptanCodes?: string[];
     commonName?: string;
-    adminAreaCodes?: string;
+    adminAreaCodes?: string[];
     page?: number;
 };
 

--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -68,7 +68,7 @@ export const getOperators = async (dbClient: Kysely<Database>, input: OperatorQu
 export type StopsQueryInput = {
     atcoCodes?: string[];
     naptanCodes?: string[];
-    commonNames?: string[];
+    commonName?: string;
     adminAreaCode?: string;
     page?: number;
 };
@@ -82,13 +82,13 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
         const stopsByAdminAreaCode = await dbClient
             .selectFrom("stops")
             .selectAll()
-            .$if(!!(input.atcoCodes || input.naptanCodes || input.commonNames), (qb) =>
+            .$if(!!(input.atcoCodes || input.naptanCodes || input.commonName), (qb) =>
                 qb
                     .where("naptanCode", "in", input.naptanCodes ?? ["---"])
                     .orWhere("atcoCode", "in", input.atcoCodes ?? ["---"])
-                    .orWhere("commonName", "in", input.commonNames ?? ["---"]),
+                    .orWhere("commonName", "like", input.commonName ? `%${input.commonName}%` : "---"),
             )
-            .where("stops.administrativeAreaCode", "=", input.adminAreaCode)
+            .where("administrativeAreaCode", "=", input.adminAreaCode)
             .execute();
 
         if (!stopsByAdminAreaCode) {
@@ -98,7 +98,7 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
         return stopsByAdminAreaCode;
     }
 
-    if (input.atcoCodes || input.naptanCodes || input.commonNames) {
+    if (input.atcoCodes || input.naptanCodes || input.commonName) {
         return dbClient
             .selectFrom("stops")
             .selectAll()
@@ -106,7 +106,7 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
                 qb
                     .where("naptanCode", "in", input.naptanCodes ?? ["---"])
                     .orWhere("atcoCode", "in", input.atcoCodes ?? ["---"])
-                    .orWhere("commonName", "in", input.commonNames ?? ["---"]),
+                    .orWhere("commonName", "like", input.commonName ? `%${input.commonName}%` : "---"),
             )
             .offset((input.page || 0) * STOPS_PAGE_SIZE)
             .limit(STOPS_PAGE_SIZE)

--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -90,6 +90,8 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
                     .orWhere("commonName", "like", input.commonName ? `%${input.commonName}%` : "---"),
             )
             .where("administrativeAreaCode", "=", input.adminAreaCode)
+            .offset((input.page || 0) * STOPS_PAGE_SIZE)
+            .limit(STOPS_PAGE_SIZE)
             .execute();
 
         if (!stopsByAdminAreaCode) {

--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -79,6 +79,7 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
     const STOPS_PAGE_SIZE = 1000;
 
     if (input.adminAreaCode) {
+        logger.info("Filtering by admin area code...");
         const stopsByAdminAreaCode = await dbClient
             .selectFrom("stops")
             .selectAll()
@@ -99,6 +100,7 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
     }
 
     if (input.atcoCodes || input.naptanCodes || input.commonName) {
+        logger.info("Filtering by other attributes...");
         return dbClient
             .selectFrom("stops")
             .selectAll()

--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -75,7 +75,6 @@ export type StopsQueryInput = {
 
 export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInput) => {
     logger.info("Starting getStops...");
-    logger.info(process.env.NODE_ENV ?? "");
 
     const STOPS_PAGE_SIZE = process.env.IS_LOCAL === "true" ? 50 : 1000;
 

--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -79,7 +79,6 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
 
     const STOPS_PAGE_SIZE = process.env.IS_LOCAL === "true" ? 50 : 1000;
 
-    logger.info("Filtering by admin area code...");
     const stops = await dbClient
         .selectFrom("stops")
         .select([

--- a/packages/api/get-stops.test.ts
+++ b/packages/api/get-stops.test.ts
@@ -14,6 +14,16 @@ describe("get-stops", () => {
             expect(getQueryInput(event)).toEqual({ atcoCodes: ["test123", "test456"], page: 0 });
         });
 
+        it("handles commonName", () => {
+            const event = {
+                queryStringParameters: {
+                    commonName: "test",
+                },
+            } as unknown as APIGatewayEvent;
+
+            expect(getQueryInput(event)).toEqual({ commonName: "test", page: 0 });
+        });
+
         it("handles naptanCodes", () => {
             const event = {
                 queryStringParameters: {
@@ -37,6 +47,46 @@ describe("get-stops", () => {
                 naptanCodes: ["abcde", "fghij"],
                 page: 0,
             });
+        });
+
+        it("handles commonName and atcoCodes and naptanCodes", () => {
+            const event = {
+                queryStringParameters: {
+                    commonName: "test",
+                    atcoCodes: "test123,test456",
+                    naptanCodes: "abcde,fghij",
+                },
+            } as unknown as APIGatewayEvent;
+
+            expect(getQueryInput(event)).toEqual({
+                commonName: "test",
+                atcoCodes: ["test123", "test456"],
+                naptanCodes: ["abcde", "fghij"],
+                page: 0,
+            });
+        });
+
+        it("handles adminAreaCode", () => {
+            const event = {
+                pathParameters: {
+                    adminAreaCode: "009",
+                },
+            } as unknown as APIGatewayEvent;
+
+            expect(getQueryInput(event)).toEqual({ adminAreaCode: "009", page: 0 });
+        });
+
+        it("handles commonName and adminAreaCode", () => {
+            const event = {
+                pathParameters: {
+                    adminAreaCode: "009",
+                },
+                queryStringParameters: {
+                    commonName: "test",
+                },
+            } as unknown as APIGatewayEvent;
+
+            expect(getQueryInput(event)).toEqual({ commonName: "test", adminAreaCode: "009", page: 0 });
         });
 
         it("handles atcoCodes and naptanCodes with trailing or leading spaces", () => {

--- a/packages/api/get-stops.test.ts
+++ b/packages/api/get-stops.test.ts
@@ -17,7 +17,7 @@ describe("get-stops", () => {
         it("handles commonName", () => {
             const event = {
                 queryStringParameters: {
-                    commonName: "test",
+                    search: "test",
                 },
             } as unknown as APIGatewayEvent;
 
@@ -52,7 +52,7 @@ describe("get-stops", () => {
         it("handles commonName and atcoCodes and naptanCodes", () => {
             const event = {
                 queryStringParameters: {
-                    commonName: "test",
+                    search: "test",
                     atcoCodes: "test123,test456",
                     naptanCodes: "abcde,fghij",
                 },
@@ -82,7 +82,7 @@ describe("get-stops", () => {
                     adminAreaCode: "009",
                 },
                 queryStringParameters: {
-                    commonName: "test",
+                    search: "test",
                 },
             } as unknown as APIGatewayEvent;
 

--- a/packages/api/get-stops.test.ts
+++ b/packages/api/get-stops.test.ts
@@ -68,25 +68,23 @@ describe("get-stops", () => {
 
         it("handles adminAreaCode", () => {
             const event = {
-                pathParameters: {
-                    adminAreaCode: "009",
+                queryStringParameters: {
+                    adminAreaCodes: "009,001",
                 },
             } as unknown as APIGatewayEvent;
 
-            expect(getQueryInput(event)).toEqual({ adminAreaCode: "009", page: 0 });
+            expect(getQueryInput(event)).toEqual({ adminAreaCodes: ["009", "001"], page: 0 });
         });
 
         it("handles commonName and adminAreaCode", () => {
             const event = {
-                pathParameters: {
-                    adminAreaCode: "009",
-                },
                 queryStringParameters: {
                     search: "test",
+                    adminAreaCodes: "009",
                 },
             } as unknown as APIGatewayEvent;
 
-            expect(getQueryInput(event)).toEqual({ commonName: "test", adminAreaCode: "009", page: 0 });
+            expect(getQueryInput(event)).toEqual({ commonName: "test", adminAreaCodes: ["009"], page: 0 });
         });
 
         it("handles atcoCodes and naptanCodes with trailing or leading spaces", () => {

--- a/packages/api/get-stops.ts
+++ b/packages/api/get-stops.ts
@@ -55,7 +55,7 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
         ...(atcoCodes ? { atcoCodes: atcoCodesArray } : {}),
         ...(naptanCodes ? { naptanCodes: naptanCodesArray } : {}),
         ...(commonName ? { commonName } : {}),
-        ...(adminAreaCodes ? { adminAreaCodes } : {}),
+        ...(adminAreaCodes ? { adminAreaCodes: adminAreaCodeArray } : {}),
         page: page - 1,
     };
 };

--- a/packages/api/get-stops.ts
+++ b/packages/api/get-stops.ts
@@ -16,11 +16,11 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
     const adminAreaCodes = queryStringParameters?.["adminAreaCodes"] ?? "";
     const adminAreaCodeArray = adminAreaCodes
         .split(",")
-        .filter((atcoCode) => atcoCode)
-        .map((atcoCode) => atcoCode.trim());
+        .filter((adminAreaCode) => adminAreaCode)
+        .map((adminAreaCode) => adminAreaCode.trim());
 
     if (adminAreaCodeArray.length > Number(MAX_ADMIN_AREA_CODES)) {
-        throw new ClientError(`Only up to ${MAX_ATCO_CODES} ATCO codes can be provided`);
+        throw new ClientError(`Only up to ${MAX_ADMIN_AREA_CODES} administrative area codes can be provided`);
     }
 
     const atcoCodes = queryStringParameters?.["atcoCodes"] ?? "";

--- a/packages/api/get-stops.ts
+++ b/packages/api/get-stops.ts
@@ -5,7 +5,6 @@ import { executeClient } from "./execute-client";
 
 const MAX_ATCO_CODES = process.env.MAX_ATCO_CODES || "5";
 const MAX_NAPTAN_CODES = process.env.MAX_NAPTAN_CODES || "5";
-const MAX_COMMON_NAMES = "1";
 
 export const main = async (event: APIGatewayEvent): Promise<APIGatewayProxyResultV2> =>
     executeClient(event, getQueryInput, getStops);
@@ -14,12 +13,6 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
     const { pathParameters, queryStringParameters } = event;
 
     const adminAreaCode = pathParameters?.adminAreaCode;
-
-    if (adminAreaCode) {
-        return {
-            adminAreaCode,
-        };
-    }
 
     const atcoCodes = queryStringParameters?.["atcoCodes"] ?? "";
     const atcoCodesArray = atcoCodes
@@ -41,15 +34,7 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
         throw new ClientError(`Only up to ${MAX_NAPTAN_CODES} NaPTAN codes can be provided`);
     }
 
-    const commonNames = queryStringParameters?.["commonNames"] ?? "";
-    const commonNamesArray = commonNames
-        .split(",")
-        .filter((commonName) => commonName)
-        .map((commonName) => commonName.trim());
-
-    if (commonNamesArray.length > Number(MAX_COMMON_NAMES)) {
-        throw new ClientError(`Only up to ${MAX_COMMON_NAMES} common names can be provided`);
-    }
+    const commonName = queryStringParameters?.["commonName"] ?? "";
 
     const page = Number(queryStringParameters?.["page"] ?? "1");
 
@@ -60,7 +45,8 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
     return {
         ...(atcoCodes ? { atcoCodes: atcoCodesArray } : {}),
         ...(naptanCodes ? { naptanCodes: naptanCodesArray } : {}),
-        ...(commonNames ? { commonNames: commonNamesArray } : {}),
+        ...(commonName ? { commonName } : {}),
+        ...(adminAreaCode ? { adminAreaCode } : {}),
         page: page - 1,
     };
 };

--- a/packages/api/get-stops.ts
+++ b/packages/api/get-stops.ts
@@ -34,7 +34,7 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
         throw new ClientError(`Only up to ${MAX_NAPTAN_CODES} NaPTAN codes can be provided`);
     }
 
-    const commonName = queryStringParameters?.["commonName"] ?? "";
+    const commonName = queryStringParameters?.["search"] ?? "";
 
     const page = Number(queryStringParameters?.["page"] ?? "1");
 

--- a/services/migrations/1676558563-stops.mjs
+++ b/services/migrations/1676558563-stops.mjs
@@ -4,15 +4,14 @@ import { Kysely, sql } from "kysely";
  * @param db {Kysely<any>}
  */
 export async function up(db) {
-    await sql`ALTER TABLE stops ADD INDEX idx_commonName (commonName);`.execute(
-        db,
-    );
-    await sql`ALTER TABLE stops ADD INDEX idx_adminAreaCode (administrativeAreaCode);`.execute(
-        db,
-    );
+    await db.schema.createIndex("idx_commonName").on("stops").column("commonName").execute();
+    await db.schema.createIndex("idx_adminAreaCode").on("stops").column("administrativeAreaCode").execute();
 }
 
 /**
  * @param db {Kysely<any>}
  */
-export async function down(db) {}
+export async function down(db) {
+    await db.schema.dropIndex("idx_commonName").on("stops").execute();
+    await db.schema.dropIndex("idx_adminAreaCode").on("stops").execute();
+}

--- a/services/migrations/1676558563-stops.mjs
+++ b/services/migrations/1676558563-stops.mjs
@@ -1,0 +1,18 @@
+import { Kysely, sql } from "kysely";
+
+/**
+ * @param db {Kysely<any>}
+ */
+export async function up(db) {
+    await sql`ALTER TABLE stops ADD INDEX idx_commonName (commonName);`.execute(
+        db,
+    );
+    await sql`ALTER TABLE stops ADD INDEX idx_adminAreaCode (administrativeAreaCode);`.execute(
+        db,
+    );
+}
+
+/**
+ * @param db {Kysely<any>}
+ */
+export async function down(db) {}

--- a/stacks/Api.ts
+++ b/stacks/Api.ts
@@ -24,6 +24,8 @@ export function ApiStack({ stack }: StackContext) {
             DATABASE_RESOURCE_ARN: cluster.clusterArn,
             MAX_ATCO_CODES: "50",
             MAX_NAPTAN_CODES: "50",
+            MAX_ADMIN_AREA_CODES: "50",
+            IS_LOCAL: !["test", "preprod", "prod"].includes(stack.stage) ? "true" : "false",
         },
         runtime: "nodejs18.x",
         logRetention: stack.stage === "production" ? "three_months" : "two_weeks",
@@ -86,7 +88,6 @@ export function ApiStack({ stack }: StackContext) {
     const api = new Api(stack, "ref-data-service-api", {
         routes: {
             "GET /stops": stopsFunction,
-            "GET /stops/{adminAreaCode}": stopsFunction,
             "GET /operators": operatorsFunction,
             "GET /operators/{nocCode}": operatorsFunction,
             "GET /operators/{nocCode}/services": servicesFunction,

--- a/stacks/Api.ts
+++ b/stacks/Api.ts
@@ -86,6 +86,7 @@ export function ApiStack({ stack }: StackContext) {
     const api = new Api(stack, "ref-data-service-api", {
         routes: {
             "GET /stops": stopsFunction,
+            "GET /stops/{adminAreaCode}": stopsFunction,
             "GET /operators": operatorsFunction,
             "GET /operators/{nocCode}": operatorsFunction,
             "GET /operators/{nocCode}/services": servicesFunction,


### PR DESCRIPTION
- [ ] New endpoint /stops/${adminAreaCode} available which returns all stops for a given administativeAreaCode, this response should be paginated to return 1000 stops per page
- [ ] The ability to pass a search query param to the stops endpoints which will filter on the commonName field
- [ ] Indexes added to the administativeAreaCode and commonName columns

