### PR TITLE
feat: getStops search by common name and atco code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@aws-sdk/client-rds-data": "^3.418.0",
                 "@aws-sdk/client-s3": "^3.418.0",
                 "@aws-sdk/client-sns": "^3.418.0",
-                "kysely": "^0.23.4",
+                "kysely": "^0.26.3",
                 "kysely-data-api": "^0.2.0"
             },
             "devDependencies": {
@@ -11148,8 +11148,9 @@
             "license": "MIT"
         },
         "node_modules/kysely": {
-            "version": "0.23.5",
-            "license": "MIT",
+            "version": "0.26.3",
+            "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.26.3.tgz",
+            "integrity": "sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw==",
             "engines": {
                 "node": ">=14.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@aws-sdk/client-rds-data": "^3.418.0",
         "@aws-sdk/client-s3": "^3.418.0",
         "@aws-sdk/client-sns": "^3.418.0",
-        "kysely": "^0.23.4",
+        "kysely": "^0.26.3",
         "kysely-data-api": "^0.2.0"
     },
     "overrides": {

--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -53,7 +53,7 @@ export const getOperators = async (dbClient: Kysely<Database>, input: OperatorQu
                 "services.destination",
                 "services.mode",
             ])
-            .where((qb) => qb.where("services.endDate", "is", null).orWhere("services.endDate", ">=", sql`CURDATE()`))
+            .where((qb) => qb.or([qb("services.endDate", "is", null), qb("services.endDate", ">=", sql`CURDATE()`)]))
             .where("nocCode", "=", input.nocCode)
             .execute();
 
@@ -116,12 +116,12 @@ export type Operators = Awaited<ReturnType<typeof getOperators>>;
 export type StopsQueryInput = {
     atcoCodes?: string[];
     naptanCodes?: string[];
-    commonName?: string;
     adminAreaCodes?: string[];
     page?: number;
     polygon?: string;
     busStopTypes?: BusStopType[];
     stopTypes?: string[];
+    searchInput?: string;
 };
 
 export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInput) => {
@@ -155,9 +155,6 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
         .where("status", "=", "active")
         .$if(!!input.atcoCodes?.[0], (qb) => qb.where("atcoCode", "in", input.atcoCodes ?? ["---"]))
         .$if(!!input.naptanCodes?.[0], (qb) => qb.where("naptanCode", "in", input.naptanCodes ?? ["---"]))
-        .$if(!!input.commonName, (qb) =>
-            qb.where("stops.commonName", "like", input.commonName ? `%${input.commonName}%` : "---"),
-        )
         .$if(!!input.adminAreaCodes?.[0], (qb) =>
             qb
                 .where("localities.administrativeAreaCode", "in", input.adminAreaCodes ?? ["---"])
@@ -169,6 +166,14 @@ export const getStops = async (dbClient: Kysely<Database>, input: StopsQueryInpu
         )
         .$if(!!input.stopTypes?.[0], (qb) => qb.where("stopType", "in", input.stopTypes ?? ["---"]))
         .$if(!!input.busStopTypes?.[0], (qb) => qb.where("busStopType", "in", input.busStopTypes ?? ["---"]))
+        .$if(!!input.searchInput, (qb) =>
+            qb.where((eb) =>
+                eb.or([
+                    eb("stops.commonName", "like", input.searchInput ? `%${input.searchInput}%` : "---"),
+                    eb("stops.atcoCode", "like", input.searchInput ? `%${input.searchInput}%` : "---"),
+                ]),
+            ),
+        )
         .offset((input.page || 0) * STOPS_PAGE_SIZE)
         .limit(STOPS_PAGE_SIZE)
         .execute();
@@ -241,7 +246,7 @@ export const getServicesForOperator = async (dbClient: Kysely<Database>, input: 
         .where("nocCode", "=", input.nocCode)
         .where("dataSource", "=", input.dataSource)
         .$if(!!input.modes && input.modes.length > 0, (qb) => qb.where("mode", "in", input.modes ?? []))
-        .where((qb) => qb.where("services.endDate", "is", null).orWhere("services.endDate", ">=", sql`CURDATE()`))
+        .where((qb) => qb.or([qb("services.endDate", "is", null), qb("services.endDate", ">=", sql`CURDATE()`)]))
         .$if(!!input.lineNames && input.lineNames.length > 0, (qb) =>
             qb.where("services.lineName", "in", input.lineNames ?? []),
         )
@@ -306,7 +311,7 @@ export const getServiceById = async (dbClient: Kysely<Database>, input: ServiceB
         .where("services.id", "=", input.serviceId)
         .where("fromStop.stopType", "not in", ignoredStopTypes)
         .where("toStop.stopType", "not in", ignoredStopTypes)
-        .where((qb) => qb.where("services.endDate", "is", null).orWhere("services.endDate", ">=", sql`CURDATE()`))
+        .where((qb) => qb.or([qb("services.endDate", "is", null), qb("services.endDate", ">=", sql`CURDATE()`)]))
         .orderBy("services.startDate", "asc")
         .execute();
 
@@ -473,7 +478,7 @@ export const getServiceStops = async (
         .where("service_journey_patterns.journeyPatternRef", "in", journeyPatternRefs)
         .where("fromStop.stopType", "not in", ignoredStopTypes)
         .where("toStop.stopType", "not in", ignoredStopTypes)
-        .where((qb) => qb.where("fromStop.status", "=", "active").orWhere("toStop.status", "=", "active"))
+        .where((qb) => qb.or([qb("fromStop.status", "=", "active"), qb("toStop.status", "=", "active")]))
         .$if(!!input.modes?.[0], (qb) => qb.where("services.mode", "in", input.modes ?? ["---"]))
         .$if(!!input.stopTypes?.[0], (qb) =>
             qb
@@ -573,7 +578,7 @@ export const getServicesByStops = async (dbClient: Kysely<Database>, input: Serv
         .selectAll("services")
         .select(["fromAtcoCode", "toAtcoCode"])
         .distinct()
-        .where((qb) => qb.where("fromAtcoCode", "in", input.stops).orWhere("toAtcoCode", "in", input.stops))
+        .where((qb) => qb.or([qb("fromAtcoCode", "in", input.stops), qb("toAtcoCode", "in", input.stops)]))
         .where("dataSource", "=", input.dataSource)
         .orderBy("service_journey_pattern_links.fromSequenceNumber")
         .orderBy("service_journey_patterns.direction")

--- a/packages/api/get-stops.test.ts
+++ b/packages/api/get-stops.test.ts
@@ -15,14 +15,14 @@ describe("get-stops", () => {
             expect(getQueryInput(event)).toEqual({ atcoCodes: ["test123", "test456"], page: 0 });
         });
 
-        it("handles commonName", () => {
+        it("handles search input", () => {
             const event = {
                 queryStringParameters: {
                     search: "test",
                 },
             } as unknown as APIGatewayEvent;
 
-            expect(getQueryInput(event)).toEqual({ commonName: "test", page: 0 });
+            expect(getQueryInput(event)).toEqual({ searchInput: "test", page: 0 });
         });
 
         it("handles naptanCodes", () => {
@@ -50,7 +50,7 @@ describe("get-stops", () => {
             });
         });
 
-        it("handles commonName and atcoCodes and naptanCodes", () => {
+        it("handles searchInput and atcoCodes and naptanCodes", () => {
             const event = {
                 queryStringParameters: {
                     search: "test",
@@ -60,7 +60,7 @@ describe("get-stops", () => {
             } as unknown as APIGatewayEvent;
 
             expect(getQueryInput(event)).toEqual({
-                commonName: "test",
+                searchInput: "test",
                 atcoCodes: ["test123", "test456"],
                 naptanCodes: ["abcde", "fghij"],
                 page: 0,
@@ -77,7 +77,7 @@ describe("get-stops", () => {
             expect(getQueryInput(event)).toEqual({ adminAreaCodes: ["009", "001"], page: 0 });
         });
 
-        it("handles commonName and adminAreaCode", () => {
+        it("handles searchInput and adminAreaCode", () => {
             const event = {
                 queryStringParameters: {
                     search: "test",
@@ -85,7 +85,7 @@ describe("get-stops", () => {
                 },
             } as unknown as APIGatewayEvent;
 
-            expect(getQueryInput(event)).toEqual({ commonName: "test", adminAreaCodes: ["009"], page: 0 });
+            expect(getQueryInput(event)).toEqual({ searchInput: "test", adminAreaCodes: ["009"], page: 0 });
         });
 
         it("handles polygons and adminAreaCode", () => {

--- a/packages/api/get-stops.ts
+++ b/packages/api/get-stops.ts
@@ -45,7 +45,7 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
         throw new ClientError(`Only up to ${MAX_NAPTAN_CODES} NaPTAN codes can be provided`);
     }
 
-    const commonName = queryStringParameters?.search ?? "";
+    const searchInput = queryStringParameters?.search ?? "";
 
     const page = Number(queryStringParameters?.page ?? "1");
 
@@ -86,7 +86,7 @@ export const getQueryInput = (event: APIGatewayEvent): StopsQueryInput => {
     return {
         ...(atcoCodes ? { atcoCodes: atcoCodesArray } : {}),
         ...(naptanCodes ? { naptanCodes: naptanCodesArray } : {}),
-        ...(commonName ? { commonName } : {}),
+        ...(searchInput ? { searchInput } : {}),
         ...(adminAreaCodes ? { adminAreaCodes: adminAreaCodeArray } : {}),
         ...(sqlPolygon ? { polygon: sqlPolygon } : {}),
         ...(filteredBusStopTypesArray && filteredBusStopTypesArray.length > 0


### PR DESCRIPTION
upgraded kysely to v0.26. changed OR where expression in client to match format of current kysely version, changed search on getstops to query common name and atco codes