### PR TITLE
fix: update naming of lastUpdatedDatetime field to match db column

### DIFF
--- a/packages/api/client.ts
+++ b/packages/api/client.ts
@@ -641,7 +641,7 @@ export const getRoadworks = async (dbClient: Kysely<Database>, input: RoadworksQ
         .$if(!!input.permitStatus, (qb) => qb.where("roadworks.permitStatus", "=", input.permitStatus ?? null))
         .$if(!!input.lastUpdatedTimeDelta, (qb) =>
             qb.where(
-                "roadworks.lastUpdatedDateTime",
+                "roadworks.lastUpdatedDatetime",
                 ">=",
                 sql`DATE_SUB(NOW(), INTERVAL ${input.lastUpdatedTimeDelta} MINUTE)`,
             ),
@@ -710,7 +710,7 @@ export const getRoadworkById = async (dbClient: Kysely<Database>, input: Roadwor
             "roadworks.workStatus",
             "highway_authority_admin_areas.administrativeAreaCode",
             "roadworks.createdDateTime",
-            "roadworks.lastUpdatedDateTime",
+            "roadworks.lastUpdatedDatetime",
         ])
         .distinct()
         .executeTakeFirst();

--- a/packages/api/post-street-manager.test.ts
+++ b/packages/api/post-street-manager.test.ts
@@ -71,7 +71,7 @@ describe("post-street-manager", () => {
             town: "LONDON",
             currentTrafficManagementType: "Multi-way signals",
             currentTrafficManagementTypeUpdateDate: null,
-            lastUpdatedDateTime: "2020-06-04T08:00:00.000Z",
+            lastUpdatedDatetime: "2020-06-04T08:00:00.000Z",
         };
 
         expect(sqsMock.send.calledOnce).toBeTruthy();

--- a/packages/api/test/testdata.ts
+++ b/packages/api/test/testdata.ts
@@ -1118,7 +1118,7 @@ const sqsMessage = {
     town: "LONDON",
     currentTrafficManagementType: "Multi-way signals",
     currentTrafficManagementTypeUpdateDate: null,
-    lastUpdatedDateTime: "2020-06-04T08:00:00.000Z",
+    lastUpdatedDatetime: "2020-06-04T08:00:00.000Z",
 };
 
 export const mockSqsEvent = {

--- a/packages/api/utils/roadworkTypes.zod.ts
+++ b/packages/api/utils/roadworkTypes.zod.ts
@@ -89,7 +89,7 @@ export const roadworkSchema = z.object({
     town: z.string().nullable(),
     currentTrafficManagementType: trafficManagementTypes.nullable(),
     currentTrafficManagementTypeUpdateDate: z.string().datetime().nullable(),
-    lastUpdatedDateTime: z.string().datetime(),
+    lastUpdatedDatetime: z.string().datetime(),
     createdDateTime: z.string().datetime().optional(),
 });
 

--- a/packages/api/utils/snsMessageTypes.zod.ts
+++ b/packages/api/utils/snsMessageTypes.zod.ts
@@ -92,7 +92,7 @@ export const permitMessageSchema = baseMessageSchema
         town: data.object_data.town ?? null,
         currentTrafficManagementType: data.object_data.current_traffic_management_type ?? null,
         currentTrafficManagementTypeUpdateDate: data.object_data.current_traffic_manage_type_update_date ?? null,
-        lastUpdatedDateTime: data.event_time ?? null,
+        lastUpdatedDatetime: data.event_time ?? null,
     }));
 
 export type PermitMessage = z.infer<typeof permitMessageSchema>;

--- a/packages/core/db.ts
+++ b/packages/core/db.ts
@@ -252,7 +252,7 @@ export interface RoadworksTable {
     currentTrafficManagementType: TrafficManagementType | null;
     currentTrafficManagementTypeUpdateDate: string | null;
     createdDateTime: string;
-    lastUpdatedDateTime: string;
+    lastUpdatedDatetime: string;
 }
 
 export interface HighwayAuthorityAdminAreaTable {

--- a/packages/ref-data-uploaders/street-manager-uploader/index.test.ts
+++ b/packages/ref-data-uploaders/street-manager-uploader/index.test.ts
@@ -77,7 +77,7 @@ describe("street manager uploader", () => {
             town: "LONDON",
             currentTrafficManagementType: "Road closure",
             currentTrafficManagementTypeUpdateDate: null,
-            lastUpdatedDateTime: "2020-06-04T08:00:00.000Z",
+            lastUpdatedDatetime: "2020-06-04T08:00:00.000Z",
             createdDateTime: "2020-06-01T08:00:00.000Z",
         });
 

--- a/packages/ref-data-uploaders/street-manager-uploader/index.ts
+++ b/packages/ref-data-uploaders/street-manager-uploader/index.ts
@@ -36,7 +36,7 @@ export const main = async (event: SQSEvent) => {
 
         const roadworkDbInput = {
             ...roadwork.data,
-            createdDateTime: roadwork.data.lastUpdatedDateTime,
+            createdDateTime: roadwork.data.lastUpdatedDatetime,
         };
 
         await writeToRoadworksTable(roadworkDbInput, dbClient);

--- a/packages/ref-data-uploaders/street-manager-uploader/utils/index.ts
+++ b/packages/ref-data-uploaders/street-manager-uploader/utils/index.ts
@@ -38,7 +38,7 @@ export const updateToRoadworksTable = async (roadwork: RoadworksTable, dbClient:
             currentTrafficManagementType: roadwork.currentTrafficManagementType,
             currentTrafficManagementTypeUpdateDate: roadwork.currentTrafficManagementTypeUpdateDate,
             createdDateTime: roadwork.createdDateTime,
-            lastUpdatedDateTime: roadwork.lastUpdatedDateTime,
+            lastUpdatedDatetime: roadwork.lastUpdatedDatetime,
         })
         .where("permitReferenceNumber", "=", roadwork.permitReferenceNumber)
         .execute();


### PR DESCRIPTION
In the roadworks table the last updated column name is called "lastUpdatedDatetime" the types used for kysely reference "lastUpdatedDateTime" - updated to match column name.