### PR TITLE
revert: remove transformation of easting northing

### DIFF
--- a/packages/ref-data-uploaders/txc-uploader/index.py
+++ b/packages/ref-data-uploaders/txc-uploader/index.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.INFO)
 db_connection = aurora_data_api.connect(
     aurora_cluster_arn=os.getenv("CLUSTER_ARN"),
     database=os.getenv("DATABASE_NAME"),
-    secret_arn=os.getenv("DATABASE_SECRET_ARN")
+    secret_arn=os.getenv("DATABASE_SECRET_ARN"),
 )
 
 

--- a/packages/ref-data-uploaders/txc-uploader/requirements.test.txt
+++ b/packages/ref-data-uploaders/txc-uploader/requirements.test.txt
@@ -4,4 +4,3 @@ aurora-data-api==0.4.0
 xmltodict==0.13.0
 pytest==7.4.0
 moto==4.1.14
-pyproj==3.7.1

--- a/packages/ref-data-uploaders/txc-uploader/requirements.txt
+++ b/packages/ref-data-uploaders/txc-uploader/requirements.txt
@@ -2,4 +2,3 @@ boto3==1.28.26
 botocore==1.31.26
 aurora-data-api==0.4.0
 xmltodict==0.13.0
-pyproj==3.7.1

--- a/packages/ref-data-uploaders/txc-uploader/tests/conftest.py
+++ b/packages/ref-data-uploaders/txc-uploader/tests/conftest.py
@@ -3,26 +3,29 @@ import pytest
 import boto3
 from moto import mock_s3, mock_ssm, mock_cloudwatch
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
-    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
-    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
-    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
-    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def s3(aws_credentials):
     with mock_s3():
-        yield boto3.client('s3', region_name='eu-west-2')
+        yield boto3.client("s3", region_name="eu-west-2")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def ssm(aws_credentials):
     with mock_ssm():
-        yield boto3.client('ssm', region_name='eu-west-2')
+        yield boto3.client("ssm", region_name="eu-west-2")
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def cloudwatch(aws_credentials):
     with mock_cloudwatch():
-        yield boto3.client('cloudwatch', region_name='eu-west-2')
+        yield boto3.client("cloudwatch", region_name="eu-west-2")

--- a/packages/ref-data-uploaders/txc-uploader/tests/helpers/test_xml_helpers.py
+++ b/packages/ref-data-uploaders/txc-uploader/tests/helpers/test_xml_helpers.py
@@ -31,6 +31,7 @@ def generate_mock_invalid_data_dict():
 
     return mock_data_dict
 
+
 def generate_mock_ferry_txc_data_dict():
     tree = eT.parse(f"{dir_path}/test_data/mock_ferry_txc.xml")
     xml_data = tree.getroot()

--- a/packages/ref-data-uploaders/txc-uploader/tests/test_txc_uploader.py
+++ b/packages/ref-data-uploaders/txc-uploader/tests/test_txc_uploader.py
@@ -283,7 +283,7 @@ class TestDataCollectionFunctionality:
 
 
 class TestCollectTrackData:
-    def test_omit_easting_northing_to_long_lat_when_missing(self):
+    def test_omit_easting_northing_from_tracks(self):
         route_sections = [
             {
                 "@id": "section1",

--- a/packages/ref-data-uploaders/txc-uploader/tests/test_txc_uploader.py
+++ b/packages/ref-data-uploaders/txc-uploader/tests/test_txc_uploader.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import ANY, patch, MagicMock
 from aurora_data_api import AuroraDataAPICursor
-from pyproj import Transformer
 
 
 import boto3
@@ -284,7 +283,7 @@ class TestDataCollectionFunctionality:
 
 
 class TestCollectTrackData:
-    def test_convert_easting_northing_to_long_lat_when_missing(self):
+    def test_omit_easting_northing_to_long_lat_when_missing(self):
         route_sections = [
             {
                 "@id": "section1",
@@ -318,9 +317,7 @@ class TestCollectTrackData:
         route_section_refs = ["section1"]
         link_refs = ["link1"]
         expected_routes = [
-            {"longitude": -0.554729502, "latitude": 51.689858772},
             {"longitude": 1.1111, "latitude": 2.2222},
-            {"latitude": 52.561062301, "longitude": 0.949152044},
             {"longitude": 3.3333, "latitude": 4.4444},
         ]
 
@@ -360,7 +357,6 @@ class TestCollectTrackData:
         route_section_refs = ["section1"]
         link_refs = ["link1"]
         expected_routes = [
-            {"longitude": -0.554729502, "latitude": 51.689858772},
             {"longitude": 1.1111, "latitude": 2.2222},
         ]
 

--- a/packages/ref-data-uploaders/txc-uploader/txc_processor.py
+++ b/packages/ref-data-uploaders/txc-uploader/txc_processor.py
@@ -1,6 +1,5 @@
 import itertools
 from typing import Optional
-from pyproj import Transformer
 
 import aurora_data_api
 import xmltodict
@@ -658,31 +657,9 @@ def extract_coordinates(location):
     if translation is None:
         longitude = location.get("Longitude", None)
         latitude = location.get("Latitude", None)
-        if longitude is None or latitude is None:
-            easting = location.get("Easting", None)
-            northing = location.get("Northing", None)
-            if easting is not None and northing is not None:
-                transformer = Transformer.from_crs(
-                    "EPSG:27700", "EPSG:4326", always_xy=True
-                )
-                longitude, latitude = map(
-                    lambda coord: round(coord, 9),
-                    transformer.transform(easting, northing),
-                )
     else:
         longitude = translation.get("Longitude", None)
         latitude = translation.get("Latitude", None)
-        if longitude is None or latitude is None:
-            easting = translation.get("Easting", None)
-            northing = translation.get("Northing", None)
-            if easting is not None and northing is not None:
-                transformer = Transformer.from_crs(
-                    "EPSG:27700", "EPSG:4326", always_xy=True
-                )
-                longitude, latitude = map(
-                    lambda coord: round(coord, 9),
-                    transformer.transform(easting, northing),
-                )
     return longitude, latitude
 
 


### PR DESCRIPTION
This PR is to partially revert changes in PR: https://github.com/Department-for-Transport-Disruptions/reference-data-service/pull/146

The original changes involved converting easting/northing coordinates to longitude/latitude when processing timetable data. However, this significantly increased the volume of data inserted into the database, leading to errors in test and preprod environments.

To address this, the current PR temporarily removes the coordinate conversion logic and safely skips track data that includes only easting/northing or lacks longitude/latitude.

This fix restores processing of TNDS timetables in production and fixes a live bug. It will also allow the database issues related to easting/northing conversion to be resolved separately.