### PR TITLE
chore: Remove package-lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 node_modules
+**/package-lock.json
 
 # sst
 .sst


### PR DESCRIPTION
Codebase was migrated to pnpm a while back. There's an empty package-lock file which I think is causing dependabot actions to fail and create noise on the repos gh actions list. PR to remove.