### PR TITLE
fix: update worksLocationCoordinates column to be text

### DIFF
--- a/services/migrations/1754046609-works_location_coord_text.mjs
+++ b/services/migrations/1754046609-works_location_coord_text.mjs
@@ -1,0 +1,15 @@
+import { sql } from "kysely";
+
+/**
+ * @param db {Kysely<any>}
+ */
+export async function up(db) {
+    await sql`ALTER TABLE roadworks MODIFY worksLocationCoordinates TEXT`.execute(db);
+}
+
+/**
+ * @param db {Kysely<any>}
+ */
+export async function down(db) {
+    await sql`ALTER TABLE roadworks MODIFY worksLocationCoordinates VARCHAR(10000)`.execute(db);
+}


### PR DESCRIPTION
Some roadworks messages were not being processed because their worksLocationCoordinates were over 10000 characters. (This happens when a roadwork has an bounding box of many points)

This is an update to change the column to a text field which can handle 1GB data. 